### PR TITLE
feat(server): vary cache age btw index and assets

### DIFF
--- a/src/server/env.coffee
+++ b/src/server/env.coffee
@@ -2,7 +2,8 @@
 
 module.exports =
   STATIC_DIR: 'static'
-  CACHE_AGE: parseInt process.env.ARRAYRES_CACHE_AGE, 10
+  CACHE_AGE_INDEX: parseInt process.env.ARRAYRES_CACHE_AGE_INDEX, 10
+  CACHE_AGE_ASSETS: parseInt process.env.ARRAYRES_CACHE_AGE_ASSETS, 10
   PORT: parseInt process.env.ARRAYRES_PORT, 10
   SESSION:
     secret: process.env.ARRAYRES_SESSION_SECRET

--- a/src/server/server.coffee
+++ b/src/server/server.coffee
@@ -31,13 +31,16 @@ ensureAuthenticated = (request, response, next) ->
     .status 401
     .json error: 'not authenticated'
 
+# Static file server middleware:
 staticDir = path.resolve __dirname, env.STATIC_DIR
-staticFileServer = serveStatic staticDir, maxAge: env.CACHE_AGE
+staticFileServer = serveStatic staticDir,
+  maxAge: env.CACHE_AGE_ASSETS
+  index: false
 
 # HTML5 mode middleware:
 indexFileServer = (request, response) ->
   indexFilePath = path.resolve staticDir, 'index.html'
-  response.sendFile indexFilePath, maxAge: env.CACHE_AGE
+  response.sendFile indexFilePath, maxAge: env.CACHE_AGE_INDEX
 
 # Server:
 (do express)


### PR DESCRIPTION
Because we have revision hashes for static assets
we can now specify longer cache age, however this
should not be the case for the index file. Thus
index file uses different cache age configuration
compared to other static assets.
