### PR TITLE
chore(build): remove --dest option

### DIFF
--- a/gulp/config.coffee
+++ b/gulp/config.coffee
@@ -3,10 +3,6 @@
 # @module gulp/config
 #
 
-minimist = require 'minimist'
-
-argv = minimist process.argv[2..]
-
 src = {}
 dest = {}
 
@@ -60,7 +56,7 @@ src.serverData = [
 # Source files and folders
 # --------------------
 
-dest.buildRoot = argv.dest or 'build'
+dest.buildRoot = 'build'
 
 dest.serverRoot = "#{dest.buildRoot}/server"
 

--- a/gulp/tasks/shared/clean-build.coffee
+++ b/gulp/tasks/shared/clean-build.coffee
@@ -12,8 +12,4 @@ module.exports = (done) ->
   del = require 'del'
   config = require '../../config'
 
-  # We need the force options to allow working
-  # on directories outside the cwd:
-  delOptions = force: yes
-
-  del config.dest.buildRoot, delOptions, done
+  del config.dest.buildRoot, done

--- a/gulpfile.litcoffee
+++ b/gulpfile.litcoffee
@@ -7,9 +7,7 @@ This is the build system for ArrayResUi.
 - Run `gulp dev:build` to build a development version.
 - Run `gulp dist:build` to build a distribution version.
 
-By default both *dev* and *dist* will write the generated code to the *./build*
-folder. Use `--dest` option to modify this behavior. Useful when deploying to
-the production environment, e.g. `gulp dist --dest="/srv/arrayresui"`.
+Both *dev* and *dist* will write the generated code to the *./build* folder.
 
 
     require('gulp')

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.4",
     "gulp-watch": "^4.3.4",
-    "minimist": "^1.1.0",
     "run-sequence": "^1.0.2",
     "stream-series": "^0.1.1",
     "vinyl-buffer": "^1.0.0",


### PR DESCRIPTION
This simplifies the build and doesn't require
the force: true option for del. The destination
should be handled by the deployment script.
